### PR TITLE
Fix simple_query row order and COPY number of results

### DIFF
--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -1293,7 +1293,7 @@ module Make (Thread : IO) = struct
       | _, Message_in.CopyData row ->
         loop acc ([row |> deserialize_string |> Value.of_string]::rows) state
       | _, Message_in.CopyDone ->
-        loop ((List.rev rows)::acc) [] state
+        loop acc rows state
       | `Rows, Message_in.DataRow row ->
         let row =
           List.map (Option.bind (fun v ->

--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -1303,6 +1303,7 @@ module Make (Thread : IO) = struct
         in
         loop acc (row::rows) `Rows
       | (`Row_desc |  `Rows ), Message_in.CommandComplete _ ->
+        let rows = List.rev rows in
         loop (rows::acc) [] `Row_desc
       | `Row_desc, Message_in.RowDescription _ -> loop acc rows `Rows
       | _, Message_in.ReadyForQuery _ ->

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -144,6 +144,15 @@ module Make_tests (IO : Pgx.IO) = struct
               ; [[Some "2"]]
               ; [[Some "3"]]] )
         )
+      ; "query - multiple single query", (fun () ->
+          with_conn (fun dbh ->
+            simple_query dbh "select 1 union all select 2 union all select 3"
+            >>| assert_equal
+            ~printer:pretty_print_string_option_list_list_list
+              [[ [Some "1"]
+               ; [Some "2"]
+               ; [Some "3"]]] )
+        )
       ; "query - empty", (fun () ->
           with_conn (fun dbh ->
             simple_query dbh "" >>|

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -283,14 +283,14 @@ module Make_tests (IO : Pgx.IO) = struct
       ; "copy out simple query", (fun () ->
           with_temp_db (fun dbh ~db_name:_ ->
             simple_query dbh
-              ("CREATE TABLE tennis_greats ( \
-                name            varchar(40), \
-                grand_slams     integer); \
-                INSERT INTO tennis_greats VALUES \
-                ('Roger Federer', 19), \
-                ('Rafael Nadal', 15); \
-                COPY tennis_greats TO STDOUT (DELIMITER '|')")
-            >>| assert_equal [[];[];[[Some "Roger Federer|19\n"];[Some "Rafael Nadal|15\n"]];[]])
+              "CREATE TABLE tennis_greats ( \
+               name            varchar(40), \
+               grand_slams     integer); \
+               INSERT INTO tennis_greats VALUES \
+               ('Roger Federer', 19), \
+               ('Rafael Nadal', 15); \
+               COPY tennis_greats TO STDOUT (DELIMITER '|')"
+            >>| assert_equal [[];[];[[Some "Roger Federer|19\n"];[Some "Rafael Nadal|15\n"]]])
         )
       ; "copy out extended query", (fun () ->
           with_temp_db (fun dbh ~db_name:_ ->


### PR DESCRIPTION
There were two bugs here:

 - COPY was adding an extra [] to the end of the result set
 - simple_query was reversing the order of output rows

This fixes both by making COPY use the same code as other
result sets, and adding a reverse there.