### PR TITLE
Add jbuilder build dependency

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -16,6 +16,7 @@ depends: [
   "re"
 
   "bisect_ppx" {build & >= "1.3.1"}
+  "jbuilder" {build & >= "1.0+beta14"}
 
   "base64" {test}
   "ounit" {test}


### PR DESCRIPTION
This was missing but worked because of transitive dependencies.

Note: This is the lowest version we've tested, not the highest,
since we want to make the dependency as broad as possible.
As soon as beta17 comes out we'll need to bump our minimum
version though (for inline test support).