### PR TITLE
Support Async v0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update opam
+          command: |
+            opam remote remove default
+            opam remote add default https://opam.ocaml.org
+      - run:
           name: Pin packages
           command: |
             opam pin add -y -n pgx .

--- a/pgx/src/jbuild
+++ b/pgx/src/jbuild
@@ -5,4 +5,4 @@
   (public_name pgx)
   (wrapped false)
   (libraries (uuidm re))
-  (preprocess (pps (bisect_ppx -conditional ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (ppx_jane bisect_ppx -conditional)))))

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -11,7 +11,7 @@ install: [jbuilder install]
 remove: [jbuilder uninstall]
 
 depends: [
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.10.0"}
   "pgx"
   "ppx_jane"
 

--- a/pgx_async/bin/pgx_async_example.ml
+++ b/pgx_async/bin/pgx_async_example.ml
@@ -169,7 +169,7 @@ let main () =
        >>| fun x -> printf !"%{sexp: Pgx.row list list}\n" x
     )
 
-let () = 
+let () =
   let summary = "example command" in
-  Command.async ~summary Command.Spec.empty main
+  Command.async_spec ~summary Command.Spec.empty main
   |> Command.run

--- a/pgx_async/src/jbuild
+++ b/pgx_async/src/jbuild
@@ -4,5 +4,6 @@
  ((name pgx_async)
   (public_name pgx_async)
   (wrapped false)
+  (flags (:standard -safe-string))
   (libraries (async pgx))
-  (preprocess (pps (bisect_ppx -conditional ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (bisect_ppx -conditional ppx_jane)))))

--- a/pgx_lwt/src/jbuild
+++ b/pgx_lwt/src/jbuild
@@ -5,4 +5,4 @@
   (public_name pgx_lwt)
   (wrapped false)
   (libraries (lwt lwt.unix pgx))
-  (preprocess (pps (bisect_ppx -conditional ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (bisect_ppx -conditional ppx_jane)))))

--- a/pgx_unix/src/jbuild
+++ b/pgx_unix/src/jbuild
@@ -5,4 +5,4 @@
   (public_name pgx_unix)
   (wrapped false)
   (libraries (pgx))
-  (preprocess (pps (bisect_ppx -conditional ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (bisect_ppx -conditional ppx_jane)))))


### PR DESCRIPTION
Remove runner directive - this causes an error (``) with the latest `ppx_driver`. Unclear of the reason why, but removing the driver directive fixes the issue.

Async API changes
* `String.create` deprecated, now `Bytes.create`

Safe-string changes
* In preparation for 4.06, turn on safe string & make changes necessary to comply