### PR TITLE
Update .opam files: make it installable with opam

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -5,10 +5,8 @@ homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 
-build: [jbuilder build]
-build-test: [jbuilder runtest]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "ppx_jane"

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -5,10 +5,8 @@ homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 
-build: [jbuilder build]
-build-test: [jbuilder runtest]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "async" {>= "v0.10.0"}

--- a/pgx_lwt.opam
+++ b/pgx_lwt.opam
@@ -5,10 +5,8 @@ homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 
-build: [jbuilder build]
-build-test: [jbuilder runtest]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "pgx"

--- a/pgx_unix.opam
+++ b/pgx_unix.opam
@@ -5,10 +5,8 @@ homepage: "https://github.com/arenadotio/pgx"
 dev-repo: "https://github.com/arenadotio/pgx.git"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 
-build: [jbuilder build]
-build-test: [jbuilder runtest]
-install: [jbuilder install]
-remove: [jbuilder uninstall]
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name "-j" jobs]
 
 depends: [
   "pgx"


### PR DESCRIPTION
Updated the .opam files so the packages can be installed with opam.

When using Jbuilder, [the `install` and `remove` directives are no longer
necessary](http://jbuilder.readthedocs.io/en/latest/usage.html#invocation-from-opam).