### PR TITLE
Add explicit sexplib dependency to pgx

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -14,6 +14,7 @@ depends: [
   "ppx_jane"
   "uuidm"
   "re"
+  "sexplib" {>= "v0.10"}
 
   "bisect_ppx" {build & >= "1.3.1"}
   "jbuilder" {build & >= "1.0+beta14"}

--- a/pgx/src/jbuild
+++ b/pgx/src/jbuild
@@ -4,5 +4,5 @@
  ((name pgx)
   (public_name pgx)
   (wrapped false)
-  (libraries (uuidm re))
+  (libraries (uuidm re sexplib))
   (preprocess (pps (ppx_jane bisect_ppx -conditional)))))

--- a/pgx/test/jbuild
+++ b/pgx/test/jbuild
@@ -3,7 +3,7 @@
 (executables
  ((names (test_pgx_value))
   (libraries (pgx oUnit))
-	(preprocess (pps (ppx_jane ppx_driver.runner)))))
+	(preprocess (pps (ppx_jane)))))
 
 (alias
  ((name runtest)

--- a/pgx_async/bin/jbuild
+++ b/pgx_async/bin/jbuild
@@ -3,4 +3,4 @@
 (executables
  ((names (pgx_async_example))
   (libraries (core async pgx_async))
-  (preprocess (pps (ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (ppx_jane)))))

--- a/pgx_async/test/jbuild
+++ b/pgx_async/test/jbuild
@@ -3,7 +3,7 @@
 (executables
  ((names (test_pgx_async test_pgx_async_conversions))
   (libraries (pgx_async pgx_test oUnit))
-	(preprocess (pps (ppx_jane ppx_driver.runner)))))
+	(preprocess (pps (ppx_jane)))))
 
 (alias
  ((name runtest)

--- a/pgx_lwt/test/jbuild
+++ b/pgx_lwt/test/jbuild
@@ -3,7 +3,7 @@
 (executable
  ((name test_pgx_lwt)
   (libraries (pgx_test pgx_lwt))
-	(preprocess (pps (ppx_jane ppx_driver.runner)))))
+	(preprocess (pps (ppx_jane)))))
 
 (alias
  ((name runtest)

--- a/pgx_test/src/jbuild
+++ b/pgx_test/src/jbuild
@@ -4,4 +4,4 @@
  ((name pgx_test)
   (wrapped false)
   (libraries (base64 pgx oUnit))
-  (preprocess (pps (ppx_jane ppx_driver.runner)))))
+  (preprocess (pps (ppx_jane)))))

--- a/pgx_unix/test/jbuild
+++ b/pgx_unix/test/jbuild
@@ -3,7 +3,7 @@
 (executable
  ((name test_pgx_unix)
   (libraries (pgx_test pgx_unix))
-	(preprocess (pps (ppx_jane ppx_driver.runner)))))
+	(preprocess (pps (ppx_jane)))))
 
 (alias
  ((name runtest)


### PR DESCRIPTION
Somehow this was implicit before Core v0.11 but it needs to be
explicit now. Long-term we might want to see how hard it is to
remove this, since we don't really do much with sexps.