### PR TITLE
Remove ~extract_exn:true

### DIFF
--- a/pgx_async/src/pgx_async.ml
+++ b/pgx_async/src/pgx_async.ml
@@ -17,7 +17,7 @@ module Thread = struct
   let fail = raise
 
   let catch f on_exn =
-    try_with ~extract_exn:true f >>= function
+    try_with f >>= function
     | Ok x -> return x
     | Error exn -> on_exn exn
 


### PR DESCRIPTION
~extract_exn:false gives much better stack traces:

https://ocaml.janestreet.com/ocaml-core/latest/doc/async_kernel/Async_kernel/Monitor/#val-try_with