### PR TITLE
Quieter tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ coverage: clean
 	  `find . -name 'bisect*.out'`
 
 test:
-	@jbuilder runtest
+	@jbuilder runtest --force
 
 .PHONY: all build clean coverage test

--- a/pgx_async/src/pgx_async_test.ml
+++ b/pgx_async/src/pgx_async_test.ml
@@ -18,14 +18,10 @@ let ignore_empty = function
 let drop_db dbh ~db_name =
   Pga.execute dbh ("DROP DATABASE " ^ db_name)
   >>| ignore_empty
-  >>| fun () ->
-  Log.Global.debug "Dropped database %s" db_name
 
 let create_db dbh ~db_name =
   Pga.execute dbh ("CREATE DATABASE " ^ db_name)
   >>| ignore_empty
-  >>| fun () ->
-  Log.Global.debug "Created database %s" db_name
 
 let with_temp_db f =
   let db_name = random_db () in

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -45,12 +45,12 @@ module Make_tests (IO : Pgx.IO) = struct
       | _::_ -> invalid_arg "ignore_empty" in
     let create_db dbh ~db_name =
       execute dbh ("CREATE DATABASE " ^ db_name) >>|
-      ignore_empty >>= fun () ->
-      debug ("Created database " ^ db_name) in
+      ignore_empty
+    in
     let drop_db dbh ~db_name =
       execute dbh ("DROP DATABASE " ^ db_name) >>|
-      ignore_empty >>= fun () ->
-      debug ("Dropped database " ^ db_name) in
+      ignore_empty
+    in
     connect ~database:default_database () >>= begin fun dbh ->
       let db_name = random_db () in
       create_db dbh ~db_name >>= fun () ->
@@ -84,8 +84,6 @@ module Make_tests (IO : Pgx.IO) = struct
   let make_tests suite_name tests =
     deferred_list_map tests
       ~f: (fun ((name, test) : (string * async_test)) ->
-        debug ("Running " ^ name)
-        >>= fun () ->
         try_with test
         >>| function
         | Ok () -> (name, `Ok)
@@ -148,10 +146,10 @@ module Make_tests (IO : Pgx.IO) = struct
           with_conn (fun dbh ->
             simple_query dbh "select 1 union all select 2 union all select 3"
             >>| assert_equal
-            ~printer:pretty_print_string_option_list_list_list
-              [[ [Some "1"]
-               ; [Some "2"]
-               ; [Some "3"]]] )
+                  ~printer:pretty_print_string_option_list_list_list
+                  [[ [Some "1"]
+                   ; [Some "2"]
+                   ; [Some "3"]]] )
         )
       ; "query - empty", (fun () ->
           with_conn (fun dbh ->


### PR DESCRIPTION
Output looks like this now:

```
$ make test
test_pgx_async_conversions alias pgx_async/test/runtest
...
Ran: 3 tests in: 0.13 seconds.
OK
test_pgx_value alias pgx/test/runtest
.........................................................................................................................Not_found
Not_found
..Not_found
....................
Ran: 143 tests in: 0.22 seconds.
OK
test_pgx_lwt alias pgx_lwt/test/runtest
..............................
Ran: 30 tests in: 0.01 seconds.
OK
test_pgx_async alias pgx_async/test/runtest
..............................
Ran: 30 tests in: 0.11 seconds.
OK
test_pgx_unix alias pgx_unix/test/runtest
..............................
Ran: 30 tests in: 0.12 seconds.
OK
```

I'm not sure why the Pgx.Value tests are printing those weird `Not_found`'s. We don't have any print statements..