### PR TITLE
Remove prefixes from .descr files

### DIFF
--- a/pgx.descr
+++ b/pgx.descr
@@ -1,3 +1,3 @@
-Pgx - Pure-OCaml PostgreSQL client library
+Pure-OCaml PostgreSQL client library
 
 PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations.

--- a/pgx_async.descr
+++ b/pgx_async.descr
@@ -1,1 +1,1 @@
-Pgx_async - Pgx using Async for IO
+Pgx using Async for IO

--- a/pgx_lwt.descr
+++ b/pgx_lwt.descr
@@ -1,1 +1,1 @@
-Pgx_lwt - Pgx using Lwt for IO
+Pgx using Lwt for IO

--- a/pgx_unix.descr
+++ b/pgx_unix.descr
@@ -1,1 +1,1 @@
-Pgx_unix - PGX using the standard library's Unix module for IO (synchronous)
+PGX using the standard library's Unix module for IO (synchronous)


### PR DESCRIPTION
The name of the library shows up right next to the description in opam,
so we don't need to repeat it.

See the bottom of: https://opam.ocaml.org/packages/pgx/