### PR TITLE
Compile in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 build:
-	@jbuilder build @install @examples
+	@jbuilder build --dev @install @examples
 
 clean:
 	@rm -rf `find . -name 'bisect*.out'` _coverage

--- a/pgx/src/pgx_value.ml
+++ b/pgx/src/pgx_value.ml
@@ -1,4 +1,3 @@
-open Sexplib
 open Sexplib.Conv
 open Pgx_aux
 

--- a/pgx_async/src/pgx_async.ml
+++ b/pgx_async/src/pgx_async.ml
@@ -75,7 +75,7 @@ module Thread = struct
   let getlogin () =
     Unix.getuid ()
     |> Unix.Passwd.getbyuid_exn
-    >>| fun { name } -> name
+    >>| fun { name ; _ } -> name
 
   let debug msg =
     Print.prerr_endline msg;

--- a/pgx_async/src/pgx_async_test.mli
+++ b/pgx_async/src/pgx_async_test.mli
@@ -1,6 +1,5 @@
 (** Testing library for code that uses postgres *)
 
-open Core
 open Async
 
 val set_to_default_db : unit -> unit

--- a/pgx_lwt/src/pgx_lwt.ml
+++ b/pgx_lwt/src/pgx_lwt.ml
@@ -45,7 +45,7 @@ module Thread = struct
      | Unix path -> return (Unix.ADDR_UNIX path)
      | Inet (hostname, port) ->
        Lwt_unix.gethostbyname hostname
-       >|= fun { Lwt_unix.h_addr_list } ->
+       >|= fun { Lwt_unix.h_addr_list ; _ } ->
        let len = Array.length h_addr_list in
        let i = Random.int len in
        let addr = h_addr_list.(i) in

--- a/pgx_unix/src/pgx_unix.ml
+++ b/pgx_unix/src/pgx_unix.ml
@@ -55,7 +55,9 @@ module Simple_thread = struct
   let really_input = really_input
   let close_in = close_in
   let getlogin () =
-    Unix.getuid () |> Unix.getpwuid |> fun { Unix.pw_name } -> pw_name
+    Unix.getuid ()
+    |> Unix.getpwuid
+    |> fun { Unix.pw_name ; _ } -> pw_name
 
   let debug = prerr_endline
   let protect f ~(finally: unit -> unit) =


### PR DESCRIPTION
This turns on more warnings and makes warnings errors.

Notably, had to:

 - Remove unused functions and imports
 - Add a `; _` case when destructuring records