### PR TITLE
Make pgx_async use Async.Log

### DIFF
--- a/pgx_async/src/pgx_async.ml
+++ b/pgx_async/src/pgx_async.ml
@@ -78,8 +78,8 @@ module Thread = struct
     >>| fun { name ; _ } -> name
 
   let debug msg =
-    Print.prerr_endline msg;
-    Writer.flushed (Lazy.force Writer.stderr)
+    Log.Global.debug ~tags:["lib", "pgx_async"] "%s" msg;
+    Log.Global.flushed ()
 
   let protect f ~finally = Monitor.protect f ~finally
 


### PR DESCRIPTION
Debug messages should be printed with Log.Global.debug, not
logging directly to stderr.