### PR TITLE
Use Sexplib0 instead of Sexplib

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -13,7 +13,7 @@ depends: [
   "ppx_jane"
   "uuidm"
   "re"
-  "sexplib" {>= "v0.10"}
+  "sexplib0" {>= "v0.11.0"}
 
   "bisect_ppx" {build & >= "1.3.1"}
   "jbuilder" {build & >= "1.0+beta14"}

--- a/pgx/src/jbuild
+++ b/pgx/src/jbuild
@@ -5,5 +5,5 @@
   (public_name pgx)
   (wrapped false)
   (inline_tests ((flags (-verbose))))
-  (libraries (uuidm re sexplib))
+  (libraries (uuidm re sexplib0))
   (preprocess (pps (ppx_jane bisect_ppx -conditional)))))

--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -21,7 +21,7 @@
 
 open Pgx_aux
 open Printf
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 
 (* Necessary for ppx_assert *)
 let compare_string = Pervasives.compare
@@ -211,7 +211,7 @@ module Message_in = struct
     | UnknownMessage of char * string
   [@@deriving sexp]
 
-  let to_string t = Sexplib.Sexp.to_string_hum (sexp_of_t t)
+  let to_string t = Sexplib0.Sexp.to_string_hum (sexp_of_t t)
 
   let read (typ, msg) =
     let pos = ref 0 in

--- a/pgx/src/pgx_value.ml
+++ b/pgx/src/pgx_value.ml
@@ -1,4 +1,4 @@
-open Sexplib.Conv
+open Sexplib0.Sexp_conv
 open Pgx_aux
 
 type t = string option [@@deriving sexp_of]

--- a/pgx/test/test_pgx_value.ml
+++ b/pgx/test/test_pgx_value.ml
@@ -1,8 +1,8 @@
 open OUnit2
 open Pgx_aux
 open Printf
-open Sexplib
-open Sexplib.Conv
+open Sexplib0
+open Sexplib0.Sexp_conv
 
 open Pgx.Value
 


### PR DESCRIPTION
This should reduce the amount of dependencies needed for Pgx_unix
and Pgx_lwt