### PR TITLE
Revert "Used the unnamed prepared statement for Pgx.execute"

### DIFF
--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -1041,17 +1041,16 @@ module Make (Thread : IO) = struct
                     execute should only ever return one. Query was: %s"
             (List.length results) query)
     | _ ->
-      (* The unnamed prepared statement doesn't need to be un-prepared *)
-      Prepared.prepare db ~name:"" ~query
-      >>= Prepared.execute ~params
+      Prepared.(with_prepare db ~query ~f:(fun s ->
+        execute s ~params))
 
   let execute_iter ?(params=[]) db query ~f =
-    Prepared.prepare db ~name:"" ~query
-    >>= Prepared.execute_iter ~params ~f
+    Prepared.(with_prepare db ~query ~f:(fun s ->
+      execute_iter s ~params ~f))
 
   let execute_fold ?(params=[]) db query ~init ~f =
-    Prepared.prepare db ~name:"" ~query
-    >>= Prepared.execute_fold ~params ~init ~f
+    Prepared.(with_prepare db ~query ~f:(fun s ->
+      execute_fold s ~params ~init ~f))
 
   let begin_work ?isolation ?access ?deferrable seq =
     Sequencer.enqueue seq (fun conn ->


### PR DESCRIPTION
This reverts commit 0f3174d9513702033d9479812e6b807ba0956e12.

This commit wasn't async thread safe, since we could have two
async threads prepare the unnamed statement before the first
thread was able to execute it.