### PR TITLE
Replace the Pgx_async example with a better one

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,21 @@ opam pin add pgx https://github.com/arenadotio/pgx.git
 
 ## Examples
 
-See [pgx_async/bin/pgx_async_example.ml](pgx_async/bin/pgx_async_example.ml).
+See [pgx_async/bin/pgx_async_example.ml](pgx_async/bin/pgx_async_example.ml) for
+a complete example of the high-level functional interface. To translate the
+example to Lwt, replace `Pgx_async` with `Pgx_lwt` and `>>| with `>|=`. To
+translate it to synchronous IO / standard-library-only, use `Pgx_unix` and
+replace both `>>|` and `>>=` with `|>`, or just replace `>>| fun () ->` with `;`.
+
+I.e. in `Pgx_unix`, you can replace:
+
+```ocaml
+Pgx_async.execute ~params "INSERT INTO ..."
+>>| fun () ->
+```
+
+... with:
+
+```ocaml
+Pgx_unix.execute ~params "INSERT INTO ...";
+```


### PR DESCRIPTION
This focuses on the parts of the interface that people should actually use,
and has a somewhat-reasonable organization for the code.

Also made some notes about how to apply that example to Pgx_lwt and Pgx_unix.