### PR TITLE
Work around getlogin failing for lwt

### DIFF
--- a/pgx_lwt/src/pgx_lwt.ml
+++ b/pgx_lwt/src/pgx_lwt.ml
@@ -52,7 +52,11 @@ module Thread = struct
        Unix.ADDR_INET (addr, port))
     >>= Lwt_io.open_connection
 
-  let getlogin = Lwt_unix.getlogin
+  (* The unix getlogin syscall can fail *)
+  let getlogin () =
+    Unix.getuid ()
+    |> Lwt_unix.getpwuid
+    >|= fun { Lwt_unix.pw_name ; _ } -> pw_name
 
   let debug = Lwt_io.eprintl
 

--- a/pgx_unix/src/pgx_unix.ml
+++ b/pgx_unix/src/pgx_unix.ml
@@ -54,6 +54,8 @@ module Simple_thread = struct
   let input_binary_int = input_binary_int
   let really_input = really_input
   let close_in = close_in
+
+  (* The unix getlogin syscall can fail *)
   let getlogin () =
     Unix.getuid ()
     |> Unix.getpwuid


### PR DESCRIPTION
Before, I get a lot of:
```
Error: pgx_async:20:should fail without sequencer.

File
"/home/gary/dev/arena/godzilla/_build/default/pgx/pgx_lwt/test/oUnit-pgx_async-gary-macbook#01.log",
line 68, characters 1-1: Error: pgx_async:20:should fail without
sequencer (in the log).

Raised at file "pgx/pgx_test/src/pgx_test.ml", line 116, characters
20-31 Called from file "src/oUnitRunner.ml", line 46, characters 13-26

Unix.Unix_error(Unix.ENXIO, "getlogin", "")
```

After, it works