### PR TITLE
Revert "Use base64 >= 3.1.0 for tests"

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -21,6 +21,6 @@ depends: [
   "bisect_ppx" {build & >= "1.3.1"}
   "dune" {build & >= "1.1.0"}
 
-  "base64" {>= "3.1.0"}
+  "base64"
   "ounit"
 ]

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -455,12 +455,11 @@ module Make_tests (IO : Pgx.IO) = struct
       ; "binary string handling", (fun () ->
           let all_chars = String.init 255 char_of_int in
           with_conn (fun db ->
-            [ "SELECT decode($1, 'base64')",
-              Base64.encode_string all_chars, all_chars
+            [ "SELECT decode($1, 'base64')", B64.encode all_chars, all_chars
             (* Postgres adds whitespace to base64 encodings, so we strip it
                back out *)
             ; "SELECT regexp_replace(encode($1, 'base64'), '\\s', '', 'g')",
-              all_chars, Base64.encode_string all_chars ]
+              all_chars, B64.encode all_chars ]
             |> deferred_list_map ~f:(fun (query, param, expect) ->
               let params = [ param |> Pgx.Value.of_string ] in
               execute ~params db query


### PR DESCRIPTION
This reverts commit 03249c5a11b9572a10869ea2b427ae057be689b2.