### PR TITLE
Fix with-test annotations and require base64 < 3.0.0

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -21,6 +21,6 @@ depends: [
   "bisect_ppx" {build & >= "1.3.1"}
   "dune" {build & >= "1.1.0"}
 
-  "base64" {>= "3.1.0"}
-  "ounit"
+  "base64" {with-test & < "3.0.0"}
+  "ounit" {with-test}
 ]

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -455,12 +455,11 @@ module Make_tests (IO : Pgx.IO) = struct
       ; "binary string handling", (fun () ->
           let all_chars = String.init 255 char_of_int in
           with_conn (fun db ->
-            [ "SELECT decode($1, 'base64')",
-              Base64.encode_string all_chars, all_chars
+            [ "SELECT decode($1, 'base64')", B64.encode all_chars, all_chars
             (* Postgres adds whitespace to base64 encodings, so we strip it
                back out *)
             ; "SELECT regexp_replace(encode($1, 'base64'), '\\s', '', 'g')",
-              all_chars, Base64.encode_string all_chars ]
+              all_chars, B64.encode all_chars ]
             |> deferred_list_map ~f:(fun (query, param, expect) ->
               let params = [ param |> Pgx.Value.of_string ] in
               execute ~params db query


### PR DESCRIPTION
In opam 2.0, {test} should be {with-test}

We need base64 < 3.0, because the latest version is incompatible
with core-extended:

https://discuss.ocaml.org/t/what-to-do-about-files-both-define-module-base64/3426

This effectively reverts commit 03249c5a11b9572a10869ea2b427ae057be689b2