### PR TITLE
Use bisect_ppx native coveralls support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,6 @@ jobs:
           name: Build
           command: opam config exec -- make
       - run:
-          name: Test
-          command: opam config exec -- make coverage
-      - run:
-          name: Install ocveralls
-          command: opam install -y ocveralls
-      - run:
-          name: Upload coverage report
+          name: Test and coverage report
           command: |
-            cd _build/default
-            shopt -s globstar
-            opam config exec -- ocveralls **/bisect*.out --send --repo_token $COVERALLS_REPO_TOKEN --git
+            opam config exec -- make coveralls TOKEN=$COVERALLS_REPO_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ coverage: clean
 	@bisect-ppx-report -I _build/default/ -html _coverage/ \
 	  `find . -name 'bisect*.out'`
 
+coveralls: clean
+	@BISECT_ENABLE=YES dune runtest
+	@bisect-ppx-report -I _build/default/ -coveralls coverage.json \
+	  -service-name circleci -repo-token $(TOKEN) \
+	  `find . -name 'bisect*.out'`
+	@curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
+
 test:
 	@dune runtest --force
 

--- a/pgx.opam
+++ b/pgx.opam
@@ -18,7 +18,7 @@ depends: [
   "re"
   "sexplib0" {>= "v0.11.0"}
 
-  "bisect_ppx" {build & >= "1.3.1"}
+  "bisect_ppx" {build & >= "1.4.1"}
   "dune" {build & >= "1.1.0"}
 
   "base64" {with-test & < "3.0.0"}


### PR DESCRIPTION
Instead of installing a separate dependency that's marked as deprecated by the author, use the native support of bisect_ppx to generate the coveralls report.