### PR TITLE
missing job id for coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,14 @@ jobs:
           name: Build
           command: opam config exec -- make
       - run:
-          name: Test and coverage report
+          name: Test
+          command: opam config exec -- make coverage
+      - run:
+          name: Install ocveralls
+          command: opam install -y ocveralls
+      - run: 
+          name: Upload coverage report
           command: |
-            opam config exec -- make coveralls TOKEN=$COVERALLS_REPO_TOKEN
+            cd _build/default
+            shopt -s globstar
+            opam config exec -- ocveralls **/bisect*.out --send --repo_token $COVERALLS_REPO_TOKEN --git

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ coveralls: clean
 	  -service-name circle-ci -repo-token $(TOKEN) \
 	  -service-job-id ${CIRCLE_BUILD_NUM} \
 	  `find . -name 'bisect*.out'`
+	PR_NAME= echo ${CI_PULL_REQUEST} | sed 's:.*/::'
+	@sed -i '0,/{/{"service_pull_request": "$(PR_NAME)",' ./coverage.json
 	@curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ coverage: clean
 coveralls: clean
 	@BISECT_ENABLE=YES dune runtest
 	@bisect-ppx-report -I _build/default/ -coveralls coverage.json \
-	  -service-name circleci -repo-token $(TOKEN) \
+	  -service-name circle-ci -repo-token $(TOKEN) \
+	  -service-job-id ${CIRCLE_BUILD_NUM} \
 	  `find . -name 'bisect*.out'`
 	@curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,9 @@ coverage: clean
 coveralls: clean
 	@BISECT_ENABLE=YES dune runtest
 	@bisect-ppx-report -I _build/default/ -coveralls coverage.json \
-	  -service-name circle-ci -repo-token $(TOKEN) \
+	  -service-name circle-ci -repo-token ${COVERALLS_REPO_TOKEN} \
 	  -service-job-id ${CIRCLE_BUILD_NUM} \
 	  `find . -name 'bisect*.out'`
-	PR_NAME= echo ${CI_PULL_REQUEST} | sed 's:.*/::'
-	@sed -i '0,/{/{"service_pull_request": "$(PR_NAME)",' ./coverage.json
 	@curl -L -F json_file=@./coverage.json https://coveralls.io/api/v1/jobs
 
 test:


### PR DESCRIPTION
Looking at how python libs handle this, was able to connect the service job id variable to the circleci build id. bisect_ppx_report doesn't include in the docs.