### PR TITLE
Code updates and preliminary changes for Mirage compatibility

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -22,6 +22,6 @@ depends: [
   "bisect_ppx" {build & >= "1.4.1"}
   "dune" {build & >= "1.1.0"}
 
-  "base64" {with-test & < "3.0.0"}
+  "base64" {with-test & >= "3.0.0"}
   "ounit" {with-test}
 ]

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -455,11 +455,11 @@ module Make_tests (IO : Pgx.IO) = struct
       ; "binary string handling", (fun () ->
           let all_chars = String.init 255 char_of_int in
           with_conn (fun db ->
-            [ "SELECT decode($1, 'base64')", B64.encode all_chars, all_chars
+            [ "SELECT decode($1, 'base64')", Base64.encode_exn all_chars, all_chars
             (* Postgres adds whitespace to base64 encodings, so we strip it
                back out *)
             ; "SELECT regexp_replace(encode($1, 'base64'), '\\s', '', 'g')",
-              all_chars, B64.encode all_chars ]
+              all_chars, Base64.encode_exn all_chars ]
             |> deferred_list_map ~f:(fun (query, param, expect) ->
               let params = [ param |> Pgx.Value.of_string ] in
               execute ~params db query


### PR DESCRIPTION
I am experimenting with running pgx under Mirage.  I got it working, but with various patches to pgx.  This PR covers the ones I think can be merged, but I can cherry pick and send them individually if you prefer:

  - The first commit merely fixes some warnings under OCaml 4.08 related to ambiguous doc comments and reference to the now deprecated Pervasives module. About the latter, I avoided replacing it with Stdlib so we don't need to pull in the stdlib shim for backwards compatibility.
  - The second commit upgrades to base64 >= 3.0.0.
  - The third commit is the only essential one, as it eliminates dependency on the `Unix` from the API.

(I am proposing this on its own, but for the reference:

While `Unix` no longer is a direct dependency, it is pulled in along with base through `ppx_jane`.  `ppx_sexp_conv` is harmless as it only uses sexplib0, so the remaining change I needed to make it work under Mirage, apart from the IO adapter module, was:
```diff
diff --git a/pgx/src/dune b/pgx/src/dune
index f6c5b85..3ed4f7c 100644
--- a/pgx/src/dune
+++ b/pgx/src/dune
@@ -3,4 +3,4 @@
   (wrapped false)
   (inline_tests (flags (-verbose)))
   (libraries ipaddr uuidm re sexplib0)
-  (preprocess (pps ppx_jane bisect_ppx -conditional)))
+  (preprocess (pps ppx_sexp_conv)))
diff --git a/pgx/src/error_response.ml b/pgx/src/error_response.ml
index 5cc89f6..aea15a6 100644
--- a/pgx/src/error_response.ml
+++ b/pgx/src/error_response.ml
@@ -27,6 +27,7 @@ let to_string ?(verbose=false) t =
     else [] in
   String.concat "\n" (msg :: field_info)
 
+(*
 let%test_module "to_string and should_print inline tests" =
   (module struct
     let info_msg =
@@ -67,3 +68,4 @@ let%test_module "to_string and should_print inline tests" =
         let msg = { info_msg with severity } in
         [%test_result: bool] ~expect:true (should_print msg ~verbose));
   end)
+*)
diff --git a/pgx_lwt/src/dune b/pgx_lwt/src/dune
index 65f0f15..944c2f6 100644
--- a/pgx_lwt/src/dune
+++ b/pgx_lwt/src/dune
@@ -2,4 +2,4 @@
   (public_name pgx_lwt)
   (wrapped false)
   (libraries lwt lwt.unix pgx)
-  (preprocess (pps bisect_ppx -conditional ppx_jane)))
+  (preprocess (pps ppx_sexp_conv)))
```
One thing was still not quite as it should be, my `Pgx_mirage` has the following signature:
```ocaml
module Make :
  functor (Random : Mirage_random.S) ->
  functor (Clock : Mirage_clock.MCLOCK) ->
  functor (Stack : sig include Mirage_stack.V4 val singleton : t end) ->
  Pgx.S with type 'a monad = 'a Lwt.t
```
That is, I need to bring in a singleton of the network stack.  From the Mirage point of view, I think this should have been an argument to the `open_connection` function, though that would seem odd from the "normal" point of view.)