### PR TITLE
Require bisect-ppx 2.0

### DIFF
--- a/pgx.opam
+++ b/pgx.opam
@@ -19,7 +19,7 @@ depends: [
   "re"
   "sexplib0" {>= "v0.11.0"}
 
-  "bisect_ppx" {build & >= "1.4.1"}
+  "bisect_ppx" {build & >= "2.0.0"}
   "dune" {build & >= "1.1.0"}
 
   "alcotest" {with-test}

--- a/pgx/src/dune
+++ b/pgx/src/dune
@@ -2,4 +2,4 @@
   (public_name pgx)
   (wrapped false)
   (libraries ipaddr uuidm re sexplib0)
-  (preprocess (pps ppx_custom_printf ppx_sexp_conv bisect_ppx -conditional)))
+  (preprocess (pps ppx_custom_printf ppx_sexp_conv bisect_ppx --conditional)))

--- a/pgx_async/src/dune
+++ b/pgx_async/src/dune
@@ -3,4 +3,4 @@
   (wrapped false)
   (flags (:standard -safe-string))
   (libraries async pgx)
-  (preprocess (pps bisect_ppx -conditional)))
+  (preprocess (pps bisect_ppx --conditional)))

--- a/pgx_lwt/src/dune
+++ b/pgx_lwt/src/dune
@@ -2,4 +2,4 @@
   (public_name pgx_lwt)
   (wrapped false)
   (libraries lwt lwt.unix pgx)
-  (preprocess (pps bisect_ppx -conditional)))
+  (preprocess (pps bisect_ppx --conditional)))

--- a/pgx_unix/src/dune
+++ b/pgx_unix/src/dune
@@ -1,4 +1,4 @@
 (library
   (public_name pgx_unix)
   (libraries pgx)
-  (preprocess (pps bisect_ppx -conditional)))
+  (preprocess (pps bisect_ppx --conditional)))


### PR DESCRIPTION
This binary is printing annoying deprecation warnings.