### PR TITLE
Add base64 to with-tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,10 +27,6 @@
    (and
     :with-test
     (>= 1.0.0)))
-  (base64
-   (and
-    :with-test
-    (>= 3.0.0)))
   (bisect_ppx
    (and
     :dev
@@ -64,6 +60,10 @@
    (and
     :with-test
     (>= 1.0.0)))
+  (base64
+   (and
+    :with-test
+    (>= 3.0.0)))
   (ocaml
    (>= 4.08))
   (pgx
@@ -82,6 +82,10 @@
    (>= "v0.13.0"))
   (async_unix
    (>= "v0.13.0"))
+  (base64
+   (and
+    :with-test
+    (>= 3.0.0)))
   (ocaml
    (>= 4.08))
   (pgx
@@ -94,10 +98,6 @@
  (synopsis "Pgx using Lwt for IO")
  (description "Pgx using Lwt for IO")
  (depends
-  (alcotest-lwt
-   (and
-    :with-test
-    (>= "1.0.0")))
   lwt
   logs
   (ocaml
@@ -114,6 +114,10 @@
    (and
     :with-test
     (>= "1.0.0")))
+  (base64
+   (and
+    :with-test
+    (>= 3.0.0)))
   lwt
   (ocaml
    (>= 4.08))

--- a/pgx.opam
+++ b/pgx.opam
@@ -11,7 +11,6 @@ doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "alcotest" {with-test & >= "1.0.0"}
-  "base64" {with-test & >= "3.0.0"}
   "bisect_ppx" {dev & >= "2.0.0"}
   "dune" {>= "1.11"}
   "hex"

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -13,6 +13,7 @@ depends: [
   "alcotest-async" {with-test & >= "1.0.0"}
   "async_kernel" {>= "v0.13.0"}
   "async_unix" {>= "v0.13.0"}
+  "base64" {with-test & >= "3.0.0"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}
   "pgx_value_core" {= version}

--- a/pgx_lwt.opam
+++ b/pgx_lwt.opam
@@ -10,7 +10,6 @@ doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "1.11"}
-  "alcotest-lwt" {with-test & >= "1.0.0"}
   "lwt"
   "logs"
   "ocaml" {>= "4.08"}

--- a/pgx_lwt_unix.opam
+++ b/pgx_lwt_unix.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "1.11"}
   "alcotest-lwt" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
   "lwt"
   "ocaml" {>= "4.08"}
   "pgx" {= version}

--- a/pgx_unix.opam
+++ b/pgx_unix.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/arenadotio/pgx/issues"
 depends: [
   "dune" {>= "1.11"}
   "alcotest" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}
 ]


### PR DESCRIPTION
- Pgx_async, Pgx_unix, and Pgx_lwt need base64
- Pgx doesn't actually use base64
- Pgx_lwt doesn't have tests