### PR TITLE
adapt to API changes of mirage-conduit (dns resolver now has a timeout)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,11 @@ jobs:
           command: opam install --deps-only -t -y `basename -s .opam *.opam | tr '\n' ' '`
       - run:
           name: Test and coverage report
-          command: opam exec -- make coverage
+          command: |
+            coverage_set () [[ -n $COVERALLS_REPO_TOKEN ]]
+            opam exec -- make test-coverage
+            (coverage_set && opam exec -- bisect-ppx-report send-to Coveralls) || true
+
 
   dune_lint:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,7 @@ coverage: clean
 test:
 	@dune runtest --force -p $(PACKAGES)
 
+test-coverage:
+	@BISECT_ENABLE=yes dune runtest -p $(PACKAGES)
+
 .PHONY: all build clean coverage test

--- a/dune-project
+++ b/dune-project
@@ -152,9 +152,10 @@
    (>= 4.08))
   logs
   mirage-channel
-  conduit-mirage
+  (conduit-mirage (>= 2.2.0))
   dns-client
   mirage-random
+  mirage-time
   mirage-clock
   mirage-stack
   (pgx

--- a/pgx_lwt_mirage.opam
+++ b/pgx_lwt_mirage.opam
@@ -14,9 +14,10 @@ depends: [
   "ocaml" {>= "4.08"}
   "logs"
   "mirage-channel"
-  "conduit-mirage"
+  "conduit-mirage" {>= "2.2.0"}
   "dns-client"
   "mirage-random"
+  "mirage-time"
   "mirage-clock"
   "mirage-stack"
   "pgx" {= version}

--- a/pgx_lwt_mirage/src/dune
+++ b/pgx_lwt_mirage/src/dune
@@ -10,6 +10,6 @@ let () = Jbuild_plugin.V1.send @@ {|
 
 (library
  (public_name pgx_lwt_mirage)
- (libraries pgx_lwt lwt logs.lwt pgx mirage-channel conduit-mirage dns-client mirage-random mirage-clock mirage-stack)
+ (libraries pgx_lwt lwt logs.lwt pgx mirage-channel conduit-mirage dns-client mirage-random mirage-time mirage-clock mirage-stack)
  |} ^ preprocess ^ {|)
 |}

--- a/pgx_lwt_mirage/src/pgx_lwt_mirage.ml
+++ b/pgx_lwt_mirage/src/pgx_lwt_mirage.ml
@@ -80,10 +80,11 @@ end
 
 module Make
     (RANDOM : Mirage_random.S)
+    (TIME : Mirage_time.S)
     (MCLOCK : Mirage_clock.MCLOCK)
     (STACK : Mirage_stack.V4) =
 struct
-  module Dns = Dns_client_mirage.Make (RANDOM) (MCLOCK) (STACK)
+  module Dns = Dns_client_mirage.Make (RANDOM) (TIME) (MCLOCK) (STACK)
 
   type sockaddr = Thread.sockaddr =
     | Unix of string

--- a/pgx_lwt_mirage/src/pgx_lwt_mirage.mli
+++ b/pgx_lwt_mirage/src/pgx_lwt_mirage.mli
@@ -19,6 +19,7 @@
 
 module Make
     (RANDOM : Mirage_random.S)
+    (TIME : Mirage_time.S)
     (CLOCK : Mirage_clock.MCLOCK)
     (STACK : Mirage_stack.V4) : sig
   val connect : STACK.t -> (module Pgx_lwt.S)

--- a/unikernel/config.ml
+++ b/unikernel/config.ml
@@ -47,11 +47,11 @@ let server =
       ; Key.abstract database
       ]
     ~packages
-    (random @-> pclock @-> mclock @-> stackv4 @-> job)
+    (random @-> time @-> pclock @-> mclock @-> stackv4 @-> job)
 ;;
 
 let () =
   register
     "pgx_unikernel"
-    [ server $ default_random $ default_posix_clock $ default_monotonic_clock $ stack ]
+    [ server $ default_random $ default_time $ default_posix_clock $ default_monotonic_clock $ stack ]
 ;;

--- a/unikernel/config.ml
+++ b/unikernel/config.ml
@@ -53,5 +53,11 @@ let server =
 let () =
   register
     "pgx_unikernel"
-    [ server $ default_random $ default_time $ default_posix_clock $ default_monotonic_clock $ stack ]
+    [ server
+      $ default_random
+      $ default_time
+      $ default_posix_clock
+      $ default_monotonic_clock
+      $ stack
+    ]
 ;;

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -2,11 +2,12 @@ open Lwt.Infix
 
 module Make
     (RANDOM : Mirage_random.S)
+    (TIME : Mirage_time.S)
     (PCLOCK : Mirage_clock.PCLOCK)
     (MCLOCK : Mirage_clock.MCLOCK)
     (STACK : Mirage_stack.V4) =
 struct
-  module Pgx_mirage = Pgx_lwt_mirage.Make (RANDOM) (MCLOCK) (STACK)
+  module Pgx_mirage = Pgx_lwt_mirage.Make (RANDOM) (TIME) (MCLOCK) (STACK)
   module Logs_reporter = Mirage_logs.Make (PCLOCK)
 
   type user =
@@ -58,7 +59,7 @@ struct
       users
   ;;
 
-  let start _random _pclock _mclock stack =
+  let start _random _time _pclock _mclock stack =
     Logs.(set_level (Some Info));
     Logs_reporter.(create () |> run)
     @@ fun () ->


### PR DESCRIPTION
to be released in https://github.com/ocaml/opam-repository/pull/16425