### PR TITLE
Set Pgx module to wrapped

### DIFF
--- a/pgx/src/dune
+++ b/pgx/src/dune
@@ -10,7 +10,6 @@ let () = Jbuild_plugin.V1.send @@ {|
 
 (library
  (public_name pgx)
- (wrapped false)
  (libraries hex ipaddr uuidm re sexplib0)
  (preprocess (pps ppx_compare ppx_custom_printf ppx_sexp_conv |} ^ preprocess ^ {|)))
 |}

--- a/pgx/test/test_error_response.ml
+++ b/pgx/test/test_error_response.ml
@@ -1,4 +1,4 @@
-open Error_response
+open Pgx.Error_response
 
 let tests =
   let info_msg =

--- a/pgx/test/test_pgx_value.ml
+++ b/pgx/test/test_pgx_value.ml
@@ -1,4 +1,3 @@
-open Pgx_aux
 open Printf
 open Sexplib0
 open Sexplib0.Sexp_conv

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -20,8 +20,8 @@ module Alcotest_ext = struct
   let pgx_value =
     Alcotest.testable
       (fun fmt t ->
-        Pgx_value.sexp_of_t t |> Sexplib0.Sexp.to_string_hum |> Format.pp_print_string fmt)
-      (fun a b -> Pgx_value.compare a b = 0)
+        Pgx.Value.sexp_of_t t |> Sexplib0.Sexp.to_string_hum |> Format.pp_print_string fmt)
+      (fun a b -> Pgx.Value.compare a b = 0)
   ;;
 end
 

--- a/pgx_value_core/src/pgx_value_core.mli
+++ b/pgx_value_core/src/pgx_value_core.mli
@@ -1,10 +1,10 @@
 (** Pgx_value types using Core_kernel's Date and Time modules *)
 open Core_kernel
 
-type v = Pgx_value.v [@@deriving compare, sexp_of]
-type t = Pgx_value.t [@@deriving compare, sexp_of]
+type v = Pgx.Value.v [@@deriving compare, sexp_of]
+type t = Pgx.Value.t [@@deriving compare, sexp_of]
 
-include Pgx_value_intf.S with type v := v and type t := t
+include module type of Pgx.Value with type v := v and type t := t
 
 val of_date : Date.t -> t
 val to_date_exn : t -> Date.t


### PR DESCRIPTION
This makes us only expose the Pgx module at top-level.

Most of this stuff was never intended to be used directly, so the only
major change is that Pgx_value now _must_ be referenced as Pgx.Value.

Fixes #101