### PR TITLE
improve message for authentication errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: ocaml/opam2:4.09
+      - image: ocaml/opam:alpine-ocaml-4.11
         environment:
           PGUSER: pgx
           PGDATABASE: pgx-test
@@ -67,7 +67,7 @@ jobs:
 
   build_mirage:
     docker:
-      - image: ocaml/opam2:4.09
+      - image: ocaml/opam:alpine-ocaml-4.11
         environment:
           TERM: xterm
     steps:

--- a/dune-project
+++ b/dune-project
@@ -152,7 +152,10 @@
    (>= 4.08))
   logs
   mirage-channel
-  (conduit-mirage (>= 2.2.0))
+  (conduit-mirage
+   (and
+    (>= 2.2.0)
+    (< 2.3.0)))
   dns-client
   mirage-random
   mirage-time

--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -641,7 +641,8 @@ module Make (Thread : Io) = struct
         loop (Some (Message_out.Password password))
       | Message_in.AuthenticationSCMCredential ->
         fail_msg "Pgx: SCM Credential authentication not supported"
-      | Message_in.ErrorResponse err -> pg_error ~conn err
+      | Message_in.ErrorResponse err ->
+        raise (PostgreSQL_Error ("Failed to authenticate with postgres server", err))
       | Message_in.NoticeResponse _ ->
         (* XXX Do or print something here? *)
         loop None

--- a/pgx_lwt_mirage.opam
+++ b/pgx_lwt_mirage.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "logs"
   "mirage-channel"
-  "conduit-mirage" {>= "2.2.0"}
+  "conduit-mirage" {>= "2.2.0" & < "2.3.0"}
   "dns-client"
   "mirage-random"
   "mirage-time"


### PR DESCRIPTION
During the startup message flow postgres will shutdown the socket immediately after sending an error frame. Trying to read further from the socket will always result in EOF. If we instead exit early by raising the exception with  Error_response, the error message seen by pgx users will be a little better. For a login failure, before this PR we would see something like:

```
(monitor.ml.Error (Pgx_async.Pgx_eof)
 ("Raised at Pgx_async.Thread.input_char.(fun) in file \"pgx_async/src/pgx_async.ml\", line 50, characters 14-27"
  "Called from Async_kernel__Deferred1.M.map.(fun) in file \"src/deferred1.ml\", line 17, characters 40-45"
  "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 167, characters 6-47"))

```

With the diff in this PR the error will show up as:
```
(monitor.ml.Error
 (pgx/src/types.ml.PostgreSQL_Error
  "Failed to authenticate with postgres server"
  ((code 28000) (severity FATAL)
   (message "Peer authentication failed for user \"faa\"")
   (custom ((R auth_failed) (L 330) (F auth.c) (V FATAL)))))
 ("Raised at Pgx.Make.connect.(fun).loop.(fun) in file \"pgx/src/pgx.ml\", line 645, characters 8-85"
  "Called from Async_kernel__Deferred0.bind.(fun) in file \"src/deferred0.ml\", line 54, characters 64-69"
  "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 167, characters 6-47"))
```