### PR TITLE
PoC: Add TLS support

### DIFF
--- a/pgx/src/io_intf.ml
+++ b/pgx/src/io_intf.ml
@@ -14,6 +14,7 @@ module type S = sig
     | Inet of string * int
 
   val open_connection : sockaddr -> (in_channel * out_channel) t
+  val upgrade_ssl : in_channel -> out_channel -> (in_channel * out_channel) t
   val output_char : out_channel -> char -> unit t
   val output_binary_int : out_channel -> int -> unit t
   val output_string : out_channel -> string -> unit t

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -12,8 +12,10 @@ depends: [
   "dune" {>= "1.11"}
   "alcotest-async" {with-test & >= "1.0.0"}
   "async_kernel" {>= "v0.13.0"}
+  "async_ssl"
   "async_unix" {>= "v0.13.0"}
   "base64" {with-test & >= "3.0.0"}
+  "conduit-async"
   "ocaml" {>= "4.08"}
   "pgx" {= version}
   "pgx_value_core" {= version}

--- a/pgx_async/src/dune
+++ b/pgx_async/src/dune
@@ -11,6 +11,6 @@ let () = Jbuild_plugin.V1.send @@ {|
 (library
  (public_name pgx_async)
  (wrapped false)
- (libraries async_kernel async_unix pgx_value_core)
+ (libraries async_kernel async_unix conduit-async pgx_value_core)
  |} ^ preprocess ^ {|)
 |}


### PR DESCRIPTION
This adds TLS support for Pgx_async using Conduit.

This is only a proof of concept because:

- We're using the Conduit.V1 interface, which we may not want to rely on
  (the latest is V3)
- We need to add support for Pgx_async
- We probably need better error handling than asserts

Resolves #107