### PR TITLE
Print the correct library name in tests

### DIFF
--- a/pgx_async/test/test_pgx_async.ml
+++ b/pgx_async/test/test_pgx_async.ml
@@ -10,4 +10,4 @@ end
 
 include Pgx_test.Make_tests (Pgx_async) (Alcotest_io)
 
-let () = run_tests ()
+let () = run_tests ~library_name:"pgx_async"

--- a/pgx_lwt_unix/test/test_pgx_lwt.ml
+++ b/pgx_lwt_unix/test/test_pgx_lwt.ml
@@ -7,4 +7,4 @@ end
 
 include Pgx_test.Make_tests (Pgx_lwt_unix) (Alcotest_io)
 
-let () = run_tests ()
+let () = run_tests ~library_name:"pgx_lwt_unix"

--- a/pgx_test/src/pgx_test.ml
+++ b/pgx_test/src/pgx_test.ml
@@ -1,7 +1,7 @@
 external reraise : exn -> _ = "%reraise"
 
 module type S = sig
-  val run_tests : unit -> unit
+  val run_tests : library_name:string -> unit
 end
 
 module type ALCOTEST_IO = sig
@@ -110,7 +110,7 @@ struct
     output_list 0
   ;;
 
-  let run_tests () =
+  let run_tests ~library_name =
     Random.self_init ();
     set_to_default_db ();
     let tests =
@@ -614,7 +614,7 @@ struct
       ]
     in
     if force_tests || have_pg_config
-    then Alcotest_io.run "pgx_test" [ "pgx_async", tests ]
+    then Alcotest_io.run "pgx_test" [ library_name, tests ]
     else print_endline "Skipping PostgreSQL tests since PGUSER is unset."
   ;;
 end

--- a/pgx_test/src/pgx_test.mli
+++ b/pgx_test/src/pgx_test.mli
@@ -1,5 +1,5 @@
 module type S = sig
-  val run_tests : unit -> unit
+  val run_tests : library_name:string -> unit
 end
 
 module type ALCOTEST_IO = sig

--- a/pgx_unix/test/test_pgx_unix.ml
+++ b/pgx_unix/test/test_pgx_unix.ml
@@ -7,4 +7,4 @@ end
 
 include Pgx_test.Make_tests (Pgx_unix) (Alcotest_io)
 
-let () = run_tests ()
+let () = run_tests ~library_name:"pgx_unix"


### PR DESCRIPTION
This makes it so the tests don't all claim to be pgx_async and instead show the correct library name.