### PR TITLE
Opam file fixes

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -6,7 +6,7 @@
 
 (generate_opam_files true)
 
-(license "LGPL-2 with OCaml linking exception")
+(license "LGPL-2.0-only with OCaml-LGPL-linking-exception")
 
 (maintainers "Arena Developers <silver-snakes@arena.io>")
 

--- a/dune-project
+++ b/dune-project
@@ -120,7 +120,6 @@
    (and
     :with-test
     (>= 3.0.0)))
-  lwt
   (ocaml
    (>= 4.08))
   (pgx

--- a/dune-project
+++ b/dune-project
@@ -44,7 +44,8 @@
    (>= v0.13.0))
   (ppx_sexp_conv
    (>= v0.13.0))
-  re
+  (re
+   (>= 1.5.0))
   (sexplib0
    (>= v0.13.0))
   uuidm))
@@ -87,7 +88,8 @@
    (and
     :with-test
     (>= 3.0.0)))
-  conduit-async
+  (conduit-async
+   (>= 1.5.0))
   (ocaml
    (>= 4.08))
   (pgx

--- a/pgx.opam
+++ b/pgx.opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_compare" {>= "v0.13.0"}
   "ppx_custom_printf" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}
-  "re"
+  "re" {>= "1.5.0"}
   "sexplib0" {>= "v0.13.0"}
   "uuidm"
 ]

--- a/pgx.opam
+++ b/pgx.opam
@@ -5,7 +5,7 @@ description:
   "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -15,7 +15,7 @@ depends: [
   "async_unix" {>= "v0.13.0"}
   "async_ssl"
   "base64" {with-test & >= "3.0.0"}
-  "conduit-async"
+  "conduit-async" {>= "1.5.0"}
   "ocaml" {>= "4.08"}
   "pgx" {= version}
   "pgx_value_core" {= version}

--- a/pgx_async.opam
+++ b/pgx_async.opam
@@ -4,7 +4,7 @@ synopsis: "Pgx using Async for IO"
 description: "Pgx using Async for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_lwt.opam
+++ b/pgx_lwt.opam
@@ -4,7 +4,7 @@ synopsis: "Pgx using Lwt for IO"
 description: "Pgx using Lwt for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_lwt_mirage.opam
+++ b/pgx_lwt_mirage.opam
@@ -4,7 +4,7 @@ synopsis: "Pgx using Lwt on Mirage for IO"
 description: "Pgx using Lwt on Mirage for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_lwt_unix.opam
+++ b/pgx_lwt_unix.opam
@@ -4,7 +4,7 @@ synopsis: "Pgx using Lwt and Unix libraries for IO"
 description: "Pgx using Lwt and Unix libraries for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_unix.opam
+++ b/pgx_unix.opam
@@ -5,7 +5,7 @@ description:
   "PGX using the standard library's Unix module for IO (synchronous)"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/pgx_value_core.opam
+++ b/pgx_value_core.opam
@@ -4,7 +4,7 @@ synopsis: "Pgx_value converters for Core types like Date and Time"
 description: "Pgx_value converters for Core types like Date and Time"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2 with OCaml linking exception"
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"


### PR DESCRIPTION
These are fixes found by the opam release process in https://github.com/ocaml/opam-repository/pull/18675

- Make our license field SPDX compatible
- Require conduit and re versions >= 1.5.0 since we're using Re.group and Conduit_async.V3
- Remove an unnecessary dep in pgx-lwt