### PR TITLE
Dont hang on SASL logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _esy
 .merlin
 esy.lock
 node_modules
+_opam

--- a/pgx/src/pgx.ml
+++ b/pgx/src/pgx.ml
@@ -69,6 +69,7 @@ module Message_in = struct
     | AuthenticationCryptPassword of string
     | AuthenticationMD5Password of string
     | AuthenticationSCMCredential
+    | AuthenticationSASLCredential
     | BackendKeyData of int32 * int32
     | BindComplete
     | CloseComplete
@@ -155,6 +156,7 @@ module Message_in = struct
         | 4l -> AuthenticationCryptPassword (get_n_bytes 2)
         | 5l -> AuthenticationMD5Password (get_n_bytes 4)
         | 6l -> AuthenticationSCMCredential
+        | 10l -> AuthenticationSASLCredential
         | _ -> UnknownMessage (typ, msg))
       | 'H' ->
         let format_code_to_format = function
@@ -700,6 +702,8 @@ module Make (Thread : Io) = struct
         loop (Some (Message_out.Password password))
       | Message_in.AuthenticationSCMCredential ->
         fail_msg "Pgx: SCM Credential authentication not supported"
+      | Message_in.AuthenticationSASLCredential ->
+        fail_msg "Pgx: SASL Credential authentication not supported"
       | Message_in.ErrorResponse err ->
         raise (PostgreSQL_Error ("Failed to authenticate with postgres server", err))
       | Message_in.NoticeResponse _ ->


### PR DESCRIPTION
SASL is currently unsupported but has become the default in common postgres 14 setups. Instead of a hang, we can throw a real error until it can be supported.