### PR TITLE
Add support for OCaml 5.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,7 @@
    (>= 3.2))
   hex
   ipaddr
+  camlp-streams
   (ocaml
    (>= 4.08))
   (odoc :with-doc)

--- a/pgx.opam
+++ b/pgx.opam
@@ -15,6 +15,7 @@ depends: [
   "dune" {>= "3.2" & >= "3.2"}
   "hex"
   "ipaddr"
+  "camlp-streams"
   "ocaml" {>= "4.08"}
   "odoc" {with-doc}
   "ppx_compare" {>= "v0.13.0"}

--- a/pgx/src/dune
+++ b/pgx/src/dune
@@ -10,6 +10,6 @@ let () = Jbuild_plugin.V1.send @@ {|
 
 (library
  (public_name pgx)
- (libraries hex ipaddr uuidm re sexplib0)
+ (libraries hex ipaddr uuidm re sexplib0 camlp-streams)
  (preprocess (pps ppx_compare ppx_custom_printf ppx_sexp_conv |} ^ preprocess ^ {|)))
 |}


### PR DESCRIPTION
OCaml 5.0 removed `Stream` from the standard library and moved it to a separate `camlp-streams` package.